### PR TITLE
ci: allow running the workflow manually

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,10 @@
 name: CI
 
 on:
-  pull_request: {}
+  pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   verify-action:


### PR DESCRIPTION
This should help us ensure our TPS service is working properly while using the Github Action workflow.  