### PR TITLE
feat: request hcloud tokens using static tps token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,10 @@ branding:
 
 inputs:
   tps-url:
-    description: TPS endpoint URL
-    default: https://tps.hc-integrations.de/
+    description: TPS endpoint URL.
+    default: https://tps.hc-integrations.de
+  tps-token:
+    description: TPS token, if not provided, Github Actions OIDC tokens will be used.
   token:
     description: Static HCLOUD_TOKEN, will be used if provided, otherwise a token will be fetched from TPS.
 
@@ -17,5 +19,6 @@ runs:
     - run: >
         "${{ github.action_path }}/get-token.sh"
         "${{ inputs.tps-url }}"
+        "${{ inputs.tps-token }}"
         "${{ inputs.token }}"
       shell: bash

--- a/get-token.sh
+++ b/get-token.sh
@@ -3,7 +3,8 @@
 set -eu
 
 tps_url="$1"
-hcloud_token="$2"
+tps_token="$2"
+hcloud_token="$3"
 
 log() {
   echo >&2 "$*"
@@ -46,11 +47,15 @@ get_hcloud_token() {
     "$tps_url"
 }
 
+# If HCLOUD_TOKEN is not provided, fetch a token from TPS.
 if [[ -z "$hcloud_token" ]]; then
-  # Static HCLOUD_TOKEN not provided, fetch a token from TPS.
-  gha_token=$(get_gha_token)
 
-  hcloud_token="$(get_hcloud_token "$gha_token")"
+  # If TPS token is not provided, use Github Actions ID tokens.
+  if [[ -z "$tps_token" ]]; then
+    tps_token=$(get_gha_token)
+  fi
+
+  hcloud_token="$(get_hcloud_token "$tps_token")"
 fi
 
 if [[ "${hcloud_token:-}" == "" ]]; then


### PR DESCRIPTION
This allows us to use the action using static TPS tokens, instead of the Github Action OIDC tokens.  