### PR TITLE
fix: retries included the error response body

### DIFF
--- a/get-token.sh
+++ b/get-token.sh
@@ -13,7 +13,7 @@ log() {
 # do_request [<args>...]
 do_request() {
   curl \
-    --fail-with-body \
+    --fail \
     --retry 2 \
     --silent \
     --user-agent "tps-action/unknown" \
@@ -44,7 +44,10 @@ get_hcloud_token() {
   log "Requesting HCloud token"
   do_request --request POST \
     --header "Authorization: Bearer $1" \
-    "$tps_url"
+    "$tps_url" || {
+      log '::error::Failed to get token from TPS'
+      exit 1
+    }
 }
 
 # If HCLOUD_TOKEN is not provided, fetch a token from TPS.


### PR DESCRIPTION
When curl retried the request the returned output also included the body of the failed responses. This leads to parsing errors, even if the actual token was part of the response.

By using `--fail` instead curl no longer logs the bodies of the failed requests. Instead we add a manual error message for a nicer experience.